### PR TITLE
Add one-command installation option via Claude Plugins CLI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Open the link, login and authenticate your Github Copilot account.
 /plugin install claude-code-settings
 ```
 
+#### One-Command Installation 
+Use the [Claude Plugins CLI](https://claude-plugins.dev) to skip the marketplace setup:
+```bash
+npx claude-plugins install @feiskyer/claude-code-settings/claude-code-settings
+```
+
+This automatically adds the marketplace and installs the plugin in a single step.
+
 **Note:**:
 
 * [~/.claude/settings.json](settings.json) is not configured via Claude Code Plugin, you'd need to configure it manually.


### PR DESCRIPTION
## Changes
- Added "One-Command Installation" section to Quick Start
- Preserves existing installation instructions as the primary method
- Links to Claude Plugins CLI documentation

## Rationale

The standard Claude Code workflow requires users to:
1. Add marketplace: `/plugin marketplace add feiskyer/claude-code-settings`
2. Install plugin: `/plugin install claude-code-settings`

This CLI tool automates both steps:
```bash
npx claude-plugins install @feiskyer/claude-code-settings/claude-code-settings
```

Benefits:
- Reduces friction for first-time users
- Simplifies one-off installations
- Cleaner for documentation examples

## Notes
- CLI is open-source and maintained at https://github.com/Kamalnrf/claude-plugins
- No changes to plugin functionality or dependencies