### PR TITLE
chore: update .gitignore & update Anthropic model version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,6 @@ dist
 
 # vuepress v2.x temp and cache directory
 .temp
-.cache
 
 # Sveltekit cache directory
 .svelte-kit/
@@ -125,6 +124,13 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# IDE / Editor
+.vscode/
+.idea/
+
+# OS generated
+.DS_Store
+
 # yarn v3
 .pnp.*
 .yarn/*
@@ -146,3 +152,10 @@ statsig
 todos
 history.jsonl
 debug
+file-history/
+plugins/marketplaces/
+plugins/known_marketplaces.json
+.update.lock
+
+# Project specific
+WARP.md

--- a/settings.json
+++ b/settings.json
@@ -4,7 +4,7 @@
     "ANTHROPIC_AUTH_TOKEN": "sk-dummy",
     "ANTHROPIC_MODEL": "opusplan",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4.5",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4.5",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5-mini",
     "DISABLE_NON_ESSENTIAL_MODEL_CALLS": "1",
     "DISABLE_TELEMETRY": "1",


### PR DESCRIPTION
Expanded .gitignore to include IDE/editor and OS-specific files

and updated the default Anthropic Opus model in settings.json to 'claude-opus-4.5'.