### PR TITLE
docs: fix tmux LiteLLM config path example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pip install -U 'litellm[proxy]'
 litellm -c ~/.claude/guidances/litellm_config.yaml
 
 # For convenience, run litellm proxy in background with tmux
-# tmux new-session -d -s copilot 'litellm -c guidances/litellm_config.yaml'
+# tmux new-session -d -s copilot 'litellm -c ~/.claude/guidances/litellm_config.yaml'
 ```
 
 Once started, you'll see:


### PR DESCRIPTION
## What changed
- Updated the tmux background-run example to use the same absolute LiteLLM config path as the main setup command.
- Replaced `litellm -c guidances/litellm_config.yaml` with `litellm -c ~/.claude/guidances/litellm_config.yaml`.

## Why
- The repository's setup flow clones this repo to `~/.claude` and uses an absolute path for the main LiteLLM command.
- Using a relative path in the tmux example can fail when run outside the `~/.claude` directory.
- This makes the quick-start command copy-paste safe and consistent.

## Testing
- `scripts/clone_and_test.sh feiskyer/claude-code-settings`
- Tests: not run (no tests found)
