### PR TITLE
feat: add block-no-verify PreToolUse hook to block git hook bypass

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,6 +1,17 @@
 {
   "description": "Claude Code Settings plugin hooks",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx --yes block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
Closes #14

Adds block-no-verify@1.1.2 as a PreToolUse hook in hooks/hooks.json to prevent Claude Code agents from bypassing git hooks via the no-verify flag.

The hook intercepts every Bash command before it runs and blocks any git commit or push that carries the hook-bypass flag. This ensures pre-commit linters, tests, and secret scanners always execute.

Reference: https://github.com/tupe12334/block-no-verify

Disclosure: I am the author and maintainer of block-no-verify.