### PR TITLE
fix: add missing YAML frontmatter to skill-creator subagents

### DIFF
--- a/skills/skill-creator/agents/analyzer.md
+++ b/skills/skill-creator/agents/analyzer.md
@@ -1,3 +1,9 @@
+---
+name: analyzer
+description: Analyze blind comparison results to identify why the winner won and generate improvement suggestions for the losing skill. Also surfaces patterns in benchmark runs.
+tools: Read, Write
+---
+
 # Post-hoc Analyzer Agent
 
 Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.

--- a/skills/skill-creator/agents/comparator.md
+++ b/skills/skill-creator/agents/comparator.md
@@ -1,3 +1,9 @@
+---
+name: comparator
+description: Compare two skill outputs blindly to determine which better accomplishes the eval task. Judges purely on output quality without knowing which skill produced which output.
+tools: Read, Write, LS
+---
+
 # Blind Comparator Agent
 
 Compare two outputs WITHOUT knowing which skill produced them.

--- a/skills/skill-creator/agents/grader.md
+++ b/skills/skill-creator/agents/grader.md
@@ -1,3 +1,9 @@
+---
+name: grader
+description: Evaluate expectations against an execution transcript and outputs. Grades assertions pass/fail with evidence, verifies claims, and critiques evals for the skill-creator benchmarking pipeline.
+tools: Read, Write, LS, Bash
+---
+
 # Grader Agent
 
 Evaluate expectations against an execution transcript and outputs.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three subagent files in `skills/skill-creator/agents/` are missing required YAML frontmatter (`name` and `description` fields):

- `skills/skill-creator/agents/analyzer.md`
- `skills/skill-creator/agents/grader.md`
- `skills/skill-creator/agents/comparator.md`

Claude Code uses the `name` field for agent registry lookup. Without it, these agents are invisible to the registry and cannot be invoked by name. The `description` field provides trigger context that helps Claude decide when to delegate to the subagent. While these three agents are currently invoked by explicit path (e.g., `agents/grader.md`) in `SKILL.md`, the missing frontmatter means they won't appear in `claude agents list` output and won't benefit from future name-based dispatch.

## Fix

Added a minimal YAML frontmatter block to each file:

- **analyzer**: `name: analyzer`, with a description summarizing its dual role (post-hoc comparison analysis + benchmark pattern surfacing). Tools: `Read, Write`.
- **grader**: `name: grader`, describing its assertion-grading, claim-verification, and eval-critique responsibilities. Tools: `Read, Write, LS, Bash`.
- **comparator**: `name: comparator`, describing its blind A/B comparison role. Tools: `Read, Write, LS`.

The tool declarations match what each agent actually uses per its process steps. No prose content was changed.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->