### PR TITLE
Add MiniMax M3 and M2.7 settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ Please visit https://github.com/login/device and enter code XXXX-XXXX to authent
 | [vertex-settings.json](settings/vertex-settings.json) | Google Cloud Vertex AI |
 | [azure-settings.json](settings/azure-settings.json) | Azure AI（Anthropic 兼容端点） |
 | [azure-foundry-settings.json](settings/azure-foundry-settings.json) | Azure AI Foundry 原生模式 |
-| [minimax.json](settings/minimax.json) | MiniMax-M2 |
+| [minimax.json](settings/minimax.json) | MiniMax-M3, MiniMax-M2.7, and MiniMax-M2 (global endpoint) |
+| [minimax-cn.json](settings/minimax-cn.json) | MiniMax-M3, MiniMax-M2.7, and MiniMax-M2 (China endpoint) |
 | [openrouter-settings.json](settings/openrouter-settings.json) | OpenRouter（多模型统一 API） |
 
 ## 脚本工具

--- a/settings/README.md
+++ b/settings/README.md
@@ -45,7 +45,20 @@ Configuration for using Claude Code with Azure AI Foundry native mode. Uses `CLA
 
 ### [minimax.json](minimax.json)
 
-Configuration for using Claude Code with MiniMax API. Uses the MiniMax-M2 model.
+Configuration for using Claude Code with the MiniMax global Anthropic-compatible API. Uses MiniMax-M3 by default, maps the Sonnet alias to MiniMax-M2.7, and preserves MiniMax-M2 as the small-model fallback.
+
+### [minimax-cn.json](minimax-cn.json)
+
+Configuration for using Claude Code with the MiniMax China Anthropic-compatible API. It uses the same model mapping as the global configuration.
+
+#### MiniMax API endpoints
+
+| Region | Anthropic-compatible base URL | OpenAI-compatible base URL |
+|--------|-------------------------------|----------------------------|
+| Global | `https://api.minimax.io/anthropic` | `https://api.minimax.io/v1` |
+| China | `https://api.minimaxi.com/anthropic` | `https://api.minimaxi.com/v1` |
+
+Claude Code uses the Anthropic-compatible base URL and appends `/v1/messages` to it. Keep the configured base URL ending in `/anthropic`; do not append `/v1`. Use the OpenAI-compatible base URL only with clients that accept an OpenAI API base URL.
 
 ### [openrouter-settings.json](openrouter-settings.json)
 

--- a/settings/minimax-cn.json
+++ b/settings/minimax-cn.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+    "ANTHROPIC_BASE_URL": "https://api.minimaxi.com/anthropic",
     "ANTHROPIC_AUTH_TOKEN": "<MINIMAX_API_KEY>",
     "API_TIMEOUT_MS": "3000000",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- update the global target settings for MiniMax-M3 and MiniMax-M2.7 while preserving the existing fallback mapping
- add matching settings for the China endpoint
- document global and China messages-compatible and completions-compatible endpoints

## Checks
- `git diff --check`
- `jq empty settings/minimax.json settings/minimax-cn.json`
- region template parity check
- isolated messages-compatible request-path capture