### PR TITLE
Set MiniMax auto-compact window

### DIFF
--- a/settings/README.md
+++ b/settings/README.md
@@ -58,7 +58,7 @@ Configuration for using Claude Code with the MiniMax China Anthropic-compatible 
 | Global | `https://api.minimax.io/anthropic` | `https://api.minimax.io/v1` |
 | China | `https://api.minimaxi.com/anthropic` | `https://api.minimaxi.com/v1` |
 
-Claude Code uses the Anthropic-compatible base URL and appends `/v1/messages` to it. Keep the configured base URL ending in `/anthropic`; do not append `/v1`. Use the OpenAI-compatible base URL only with clients that accept an OpenAI API base URL.
+Claude Code uses the Anthropic-compatible base URL and appends `/v1/messages` to it. Keep the configured base URL ending in `/anthropic`; do not append `/v1`. Use the OpenAI-compatible base URL only with clients that accept an OpenAI API base URL. Both templates set `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to match the current one-million-token context window.
 
 ### [openrouter-settings.json](openrouter-settings.json)
 

--- a/settings/minimax-cn.json
+++ b/settings/minimax-cn.json
@@ -2,6 +2,7 @@
   "env": {
     "ANTHROPIC_BASE_URL": "https://api.minimaxi.com/anthropic",
     "ANTHROPIC_AUTH_TOKEN": "<MINIMAX_API_KEY>",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000",
     "API_TIMEOUT_MS": "3000000",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "ANTHROPIC_MODEL": "MiniMax-M3",

--- a/settings/minimax.json
+++ b/settings/minimax.json
@@ -2,6 +2,7 @@
   "env": {
     "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
     "ANTHROPIC_AUTH_TOKEN": "<MINIMAX_API_KEY>",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000",
     "API_TIMEOUT_MS": "3000000",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "ANTHROPIC_MODEL": "MiniMax-M3",


### PR DESCRIPTION
Reason: align Claude Code compaction with the current context window

## Summary
- set the one-million-token auto-compact window in both regional MiniMax templates
- document why the setting is present

## Checks
- `git diff --check`
- `jq empty settings/minimax.json settings/minimax-cn.json`
- regional template parity check
- target context and endpoint validation
